### PR TITLE
Apply SCM policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+The following is a set of guidelines for contributing to `dlisio-notebooks`.
+
+Some of the ways you can help:
+
+- Submitting bug reports: see
+  [Issues](https://github.com/equinor/dlisio-notebooks/issues).
+- Proposing code for bug fixes and new features, then [making a pull
+  request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+- Fixing typos and generally improving the documentation.
+- Writing tutorials, examples, and how-to documents.
+
+## Pull request process
+
+1. Work on your own fork of the main repo.
+1. Push your commits and make a draft pull request.
+1. Check that your pull request passes all tests.
+1. When all tests have passed and you are happy with your changes, change your
+   pull request to "ready for review", and ask for a code review.
+
+### Commits
+
+We strive to keep a consistent and clean git history and all contributions
+should adhere to the following:
+
+1. All tests should pass on all commits
+1. A commit should do one atomic change on the repository
+1. The commit headline should be descriptive and in the imperative.
+1. The commit description should be added to commits which require context
+   (explanation why the commit was introduced, reasoning for taken decisions,
+   important information about commit consequences, etc).
+1. Remove metadata and the output from Jupyer notebooks before creating a
+   commit to minimise noise in the commits and corresponding diffs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Repository Security Reporting Policy
+
+If you discover a security vulnerability in this project, please follow these
+steps to responsibly disclose it:
+
+1. **Do not** create a public GitHub issue for the vulnerability.
+2. Follow our guideline for Responsible Disclosure Policy at
+   [https://www.equinor.com/about-us/csirt](https://www.equinor.com/about-us/csirt)
+   to report the issue
+
+The following information will help us triage your report more quickly:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+We prefer all communications to be in English.


### PR DESCRIPTION
I would consider if it would be more useful to archive this repository after updating the dependencies, see #19, and applying the SCM policy (this PR). The [SCM policies](https://developer.equinor.com/governance/scm-policy/) state

> Repositories no longer maintained and not used in any production system, but still considered valuable, shall be archived (by a repo admin).

which I think applies to this repository. If active development would be necessary, we could unarchive it again. However, this repository is connected to a publication and therefore I would not expect any major changes at any time.